### PR TITLE
Add toml and fileutils

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ the compiler (e.g. "opam switch 4.03.0"), then install the build tools and build
 
 ```
 opam install oasis
-opam install xml-light lwt ppx_deriving_yojson pcre ounit
+opam install xml-light lwt ppx_deriving_yojson pcre ounit fileutils toml
 ```
 
 I also recommend that you setup utop (a great interactive REPL) and setup your editor with merlin to


### PR DESCRIPTION
Fix the following error.

```
% make
ocaml setup.ml -configure
ocamlfind: Package `toml' not found
W: Field 'pkg_toml' is not set: Command ''/Users/home/.opam/system/bin/ocamlfind' query -format %d toml > '/var/folders/nt/msxzwf9x2q19zx1frs6z36z40000gn/T/oasis-ccc21f.txt'' terminated with error code 2
ocamlfind: Package `fileutils' not found
W: Field 'pkg_fileutils' is not set: Command ''/Users/home/.opam/system/bin/ocamlfind' query -format %d fileutils > '/var/folders/nt/msxzwf9x2q19zx1frs6z36z40000gn/T/oasis-062343.txt'' terminated with error code 2
ocamlfind: Package `toml' not found
W: Failure("Command ''/Users/home/.opam/system/bin/ocamlfind' query -format %d toml > '/var/folders/nt/msxzwf9x2q19zx1frs6z36z40000gn/T/oasis-c0c1d3.txt'' terminated with error code 2")
ocamlfind: Package `fileutils' not found
W: Failure("Command ''/Users/home/.opam/system/bin/ocamlfind' query -format %d fileutils > '/var/folders/nt/msxzwf9x2q19zx1frs6z36z40000gn/T/oasis-4bac72.txt'' terminated with error code 2")
E: Cannot find findlib package fileutils
E: Cannot find findlib package toml
E: Failure("2 configuration errors")
make: *** [setup.data] Error 1
```