### PR TITLE
T226: Add secret and hidden properties to the reference tree.

### DIFF
--- a/data/schemata/interface_definition.rnc
+++ b/data/schemata/interface_definition.rnc
@@ -80,6 +80,8 @@ children = element children
 # By default, a leaf node can have only one value.
 # "multi" tag means a node can have one or more values,
 # "valueless" means it can have no values at all.
+# "hidden" means node visibility can be toggled, eg 'dangerous' commands,
+# "secret" allows a node to hide its value from unprivileged users.
 properties = element properties
 {
     help? &
@@ -89,7 +91,9 @@ properties = element properties
     # These are meaningful only for leaf nodes
     (element valueless { empty })? &
     (element multi { empty })? &
-    valueHelp*
+    (element hidden { empty })? &
+    (element secret { empty })? &
+    valueHelp* 
 }
 
 # All nodes must have "name" attribute

--- a/src/reference_tree.ml
+++ b/src/reference_tree.ml
@@ -10,6 +10,8 @@ type ref_node_data = {
     valueless: bool;
     owner: string option;
     keep_order: bool;
+    hidden: bool;
+    secret: bool;
 }
 
 type t = ref_node_data Vytree.t
@@ -28,6 +30,8 @@ let default_data = {
     valueless = false;
     owner = None;
     keep_order = false;
+    hidden = false;
+    secret = false;
 }
 
 (* Loading from XML *)
@@ -67,6 +71,8 @@ let data_from_xml d x =
         | Xml.Element ("constraintErrorMessage", _, [Xml.PCData s]) ->
             {d with constraint_error_message=s}
         | Xml.Element ("constraint", _, _) -> load_constraint_from_xml d x
+        | Xml.Element ("hidden", _, _) -> {d with hidden=true}
+        | Xml.Element ("secret", _, _) -> {d with secret=true}
         | _ -> raise (Bad_interface_definition "Malformed property tag")
     in Xml.fold aux d x
 
@@ -173,3 +179,11 @@ let rec validate_path validators_dir node path =
 let is_multi reftree path =
     let data = Vytree.get_data reftree path in
     data.multi
+
+let is_hidden reftree path =
+    let data = Vytree.get_data reftree path in
+    data.hidden
+
+let is_secret reftree path =
+    let data = Vytree.get_data reftree path in
+    data.secret

--- a/src/reference_tree.mli
+++ b/src/reference_tree.mli
@@ -10,6 +10,8 @@ type ref_node_data = {
     valueless: bool;
     owner: string option;
     keep_order: bool;
+    hidden: bool;
+    secret: bool;
 }
 
 exception Validation_error of string
@@ -23,3 +25,7 @@ val load_from_xml : t -> string -> t
 val validate_path : string -> t -> string list -> string list * string option
 
 val is_multi : t -> string list -> bool
+
+val is_hidden : t -> string list -> bool
+
+val is_secret : t -> string list -> bool

--- a/test/data/interface_definition_sample.xml
+++ b/test/data/interface_definition_sample.xml
@@ -20,6 +20,12 @@
               </leafNode>
             </children>
           </tagNode>
+          <leafNode name="password">
+            <properties>
+              <help>A password</help>
+              <secret/>
+            </properties>
+          </leafNode>
         </children>
       </node>
       <leafNode name="host-name">
@@ -41,6 +47,12 @@
             <properties>
               <help>Reboot automatically if kernel panic occurs</help>
               <valueless/>
+            </properties>
+          </leafNode>
+          <leafNode name="enable-dangerous-features">
+            <properties>
+              <help>Enable dangerous features</help>
+              <hidden/>
             </properties>
           </leafNode>
         </children>

--- a/test/reference_tree_test.ml
+++ b/test/reference_tree_test.ml
@@ -71,6 +71,25 @@ let test_is_multi_invalid test_ctxt =
     let r = load_from_xml r (in_testdata_dir test_ctxt ["interface_definition_sample.xml"]) in
     assert_equal (is_multi r ["system"; "host-name"]) false
 
+let test_is_secret_valid test_ctxt =
+    let r = Vytree.make default_data "root" in
+    let r = load_from_xml r (in_testdata_dir test_ctxt ["interface_definition_sample.xml"]) in
+    assert_equal (is_secret r ["system"; "login"; "password"]) true
+
+let test_is_secret_invalid test_ctxt =
+    let r = Vytree.make default_data "root" in
+    let r = load_from_xml r (in_testdata_dir test_ctxt ["interface_definition_sample.xml"]) in
+    assert_equal (is_secret r ["system"; "login"; "user"; "full-name"]) false
+
+let test_is_hidden_valid test_ctxt =
+    let r = Vytree.make default_data "root" in
+    let r = load_from_xml r (in_testdata_dir test_ctxt ["interface_definition_sample.xml"]) in
+    assert_equal (is_hidden r ["system"; "options"; "enable-dangerous-features"]) true
+
+let test_is_hidden_invalid test_ctxt =
+    let r = Vytree.make default_data "root" in
+    let r = load_from_xml r (in_testdata_dir test_ctxt ["interface_definition_sample.xml"]) in
+    assert_equal (is_hidden r ["system"; "login"; "user"; "full-name"]) false
 
 let suite =
     "Util tests" >::: [
@@ -86,6 +105,10 @@ let suite =
         "test_validate_path_valueless_node_valid" >:: test_validate_path_valueless_node_valid;
         "test_is_multi_valid" >:: test_is_multi_valid;
         "test_is_multi_invalid" >:: test_is_multi_invalid;
+        "test_is_secret_valid" >:: test_is_secret_valid; 
+        "test_is_secret_invalid" >:: test_is_secret_invalid;
+        "test_is_hidden_valid" >:: test_is_hidden_valid; 
+        "test_is_hidden_invalid" >:: test_is_hidden_invalid;
     ]
 
 let () =


### PR DESCRIPTION
Slightly contrived in the test interface definition xml, but does the job I think.