### PR TITLE
Add a readymade utop environment

### DIFF
--- a/.ocamlinit
+++ b/.ocamlinit
@@ -1,0 +1,30 @@
+(* Vyconf development utop environment
+ *
+ * NOTE: To keep this functioning as expected, we will need to register new
+ * package dependencies here as they are added to the project.
+ *
+ * TODO: Automate the addition of dependencies via an _oasis plugin.
+ *)
+
+let () =
+  try Topdirs.dir_directory (Sys.getenv "OCAML_TOPLEVEL_PATH")
+  with Not_found -> ()
+;;
+
+#use "topfind";;
+
+#require "lwt";;
+#require "lwt.unix";;
+#require "lwt.ppx";;
+#require "ppx_deriving.runtime";;
+#require "ppx_deriving.show";;
+#require "ppx_deriving_yojson";;
+#require "fileutils";;
+#require "pcre";;
+#require "toml";;
+#require "xml-light";;
+
+#directory "/Users/sf/Programming/VyConf/vyconf/_build";;
+#cd "_build/src";;
+
+print_string "VyConf .ocamlinit has been successfully loaded\n";;

--- a/_oasis
+++ b/_oasis
@@ -13,7 +13,8 @@ Plugins: META (0.4), DevFiles (0.4)
 
 Library "vyconf"
   Path: src
-  Modules: Vytree, Config_tree, Reference_tree, Curly_parser
+  Modules: Config_tree, Reference_tree, Curly_parser
+  InternalModules: Defaults, Directories, Startup, Util, Value_checker, Vylist, Vytree 
 
 Library "vyconf-client"
   Path: src


### PR DESCRIPTION
Adds an `.ocamlinit` file to load up all the current package dependencies along with the `_build` directory, and then cd into `_build/src`. Simply invoking `utop` in the project's root directory should put you in a position to issue the directive `#load_rec <file_name>.cmo`, and have access to all the loaded module's exported functions.

I've found this useful, but I'll take no offense to a rejection of the PR. :)