### PR TITLE
Add a bit more build and setup instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,16 +79,35 @@ and the #vyos IRC channel on Freenode.
 
 Don't forget to add unit tests for things you add or change!
 
-If you are new to OCaml, you need to install (opam)[http://opam.ocaml.org/] first, then you need to install
-the compiler (e.g. "opam switch 4.03.0"), then install the build tools and build dependencies:
+If you are new to OCaml, you need to install (opam)[http://opam.ocaml.org/]
+first. Then install the correct version of the compiler, the build tools, and
+the build dependencies:
 
 ```
+opam switch 4.03.0
 opam install oasis
-opam install xml-light lwt ppx_deriving_yojson pcre ounit fileutils toml
+opam install fileutils lwt ocplib-endian ounit pcre ppx_deriving_yojson sha toml xml-light
 ```
 
-I also recommend that you setup utop (a great interactive REPL) and setup your editor with merlin to
-see the inferred types. For GNU Emacs, consider installing tuareg-mode.
+To build the project, run the setup script, then `make`:
+
+```
+./build-setup.sh
+make
+```
+
+If the project gets in a weird state, and isn't building correctly, you can clean it up with
+
+```
+ocaml setup.ml -dist-clean
+```
+
+then build as before.
+ 
+I also recommend that you setup [utop](https://opam.ocaml.org/blog/about-utop/)
+(a great interactive REPL) and setup your editor with
+[merlin](https://github.com/ocaml/merlin) to see the inferred types. For GNU
+Emacs, consider installing [tuareg-mode](https://github.com/ocaml/tuareg).
 
 Don't hesitate to ask if you have any setup or build issues, and specifically for OCaml issues,
 there's #ocaml channel on Freenode too.


### PR DESCRIPTION
This adds a bit more information about building and setup the development info, taking into account some of the simple, but non-obvious things I figured out over the last week or so.

It also updates the list of opam dependencies for installation (and alphabetizes them, so it'll be easier to extend them as needed), and adds links for some of the tools mentioned.