### PR TITLE
T7046: T6946: add ability to reload reference tree at runtime

### DIFF
--- a/data/vyconf.proto
+++ b/data/vyconf.proto
@@ -117,6 +117,13 @@ message Request {
   message ExitConfigurationMode {
   }
 
+  message ReloadReftree {
+    // this is a temporary workaround for a bug with empty messages, and
+    // will be removed when the issue is resolved
+    optional int32 OnBehalfOf = 1;
+  }
+
+
   oneof msg {
     Status status = 1;
     SetupSession setup_session = 2;
@@ -140,6 +147,7 @@ message Request {
     ExitConfigurationMode exit_configure = 20;
     Validate validate = 21;
     Teardown teardown = 22;
+    ReloadReftree reload_reftree = 23;
   }
 }
 

--- a/data/vyconfd.conf
+++ b/data/vyconfd.conf
@@ -5,10 +5,13 @@ name = "vyconfd-minimal"
 data_dir = "/usr/share/vyos/vyconf"
 program_dir = "/usr/libexec/vyos"
 config_dir = "/usr/libexec/vyos/vyconf/config"
+reftree_dir = "/usr/libexec/vyos/vyconf/reftree"
 
 # paths relative to config_dir
 primary_config = "config.boot"
 fallback_config = "config.failsafe"
+
+# paths relative to reftree_dir
 reference_tree = "reftree.cache"
 
 [vyconf]

--- a/src/session.ml
+++ b/src/session.ml
@@ -10,8 +10,8 @@ type cfg_op =
     | CfgDelete of string list * string	option
 
 type world = {
-    running_config: CT.t;
-    reference_tree: RT.t;
+    mutable running_config: CT.t;
+    mutable reference_tree: RT.t;
     vyconf_config: Vyconf_config.t;
     dirs: Directories.t
 }

--- a/src/session.mli
+++ b/src/session.mli
@@ -3,8 +3,8 @@ type cfg_op =
     | CfgDelete of string list * string option
 
 type world = {
-    running_config: Vyos1x.Config_tree.t;
-    reference_tree: Vyos1x.Reference_tree.t;
+    mutable running_config: Vyos1x.Config_tree.t;
+    mutable reference_tree: Vyos1x.Reference_tree.t;
     vyconf_config: Vyconf_config.t;
     dirs: Directories.t
 }

--- a/src/vycli.ml
+++ b/src/vycli.ml
@@ -11,6 +11,7 @@ type op_t =
     | OpGetValues
     | OpListChildren
     | OpValidate
+    | OpReloadReftree
 
 let token : string option ref = ref None
 let conf_format_opt = ref "curly"
@@ -36,6 +37,7 @@ let args = [
     ("--show-config", Arg.Unit (fun () -> op := Some OpShowConfig), "Show the configuration at the specified path");
     ("--status", Arg.Unit (fun () -> op := Some OpStatus), "Send a status/keepalive message");
     ("--validate", Arg.Unit (fun () -> op := Some OpValidate), "Validate path");
+    ("--reload-reftree", Arg.Unit (fun () -> op := Some OpReloadReftree), "Reload reference tree");
    ]
 
 let config_format_of_string s =
@@ -77,6 +79,7 @@ let main socket op path out_format config_format =
             | OpListChildren -> list_children client path
             | OpShowConfig -> show_config client path
             | OpValidate -> validate client path
+            | OpReloadReftree -> reload_reftree client
             | _ -> Error "Unimplemented" |> Lwt.return
         end
     in match result with

--- a/src/vyconf_client.ml
+++ b/src/vyconf_client.ml
@@ -117,3 +117,12 @@ let validate client path =
     | Success -> Lwt.return (Ok "")
     | Fail -> Error (Option.value resp.error ~default:"") |> Lwt.return
     | _ -> Error (Option.value resp.error ~default:"") |> Lwt.return
+
+let reload_reftree ?(on_behalf_of=None) client =
+    let id = on_behalf_of |> (function None -> None | Some x -> (Some (Int32.of_int x))) in
+    let req = Reload_reftree {on_behalf_of=id} in
+    let%lwt resp = do_request client req in
+    match resp.status with
+    | Success -> Ok "" |> Lwt.return
+    | Fail -> Error (Option.value resp.error ~default:"") |> Lwt.return
+    | _ -> Error (Option.value resp.error ~default:"") |> Lwt.return

--- a/src/vyconf_client.mli
+++ b/src/vyconf_client.mli
@@ -42,3 +42,5 @@ val list_children : t -> string list -> (string, string) result Lwt.t
 val show_config : t -> string list -> (string, string) result Lwt.t
 
 val validate : t -> string list -> (string, string) result Lwt.t
+
+val reload_reftree : ?on_behalf_of:(int option) -> t -> (string, string) result Lwt.t

--- a/src/vyconf_client_session.ml
+++ b/src/vyconf_client_session.ml
@@ -6,6 +6,7 @@ type op_t =
     | OpTeardownSession
     | OpShowConfig
     | OpValidate
+    | OpReloadReftree
 
 let config_format_of_string s =
     match s with
@@ -42,6 +43,7 @@ let call_op ?(out_format="plain") ?(config_format="curly") socket token op path 
             | OpTeardownSession -> Vyconf_client.teardown_session client
             | OpShowConfig -> Vyconf_client.show_config client path
             | OpValidate -> Vyconf_client.validate client path
+            | OpReloadReftree -> Vyconf_client.reload_reftree client
             end
         in
         Lwt.return result
@@ -62,3 +64,6 @@ let session_show_config socket token path =
 
 let session_path_exists socket token path =
     call_op socket (Some token) (Some OpExists) path
+
+let reload_reference_tree socket =
+    call_op socket None (Some OpReloadReftree) []

--- a/src/vyconf_client_session.mli
+++ b/src/vyconf_client_session.mli
@@ -4,6 +4,7 @@ type op_t =
     | OpTeardownSession
     | OpShowConfig
     | OpValidate
+    | OpReloadReftree
 
 val session_init : ?out_format:string -> ?config_format:string -> string -> (string, string) result
 
@@ -14,3 +15,5 @@ val session_validate_path : string -> string -> string list -> (string, string) 
 val session_show_config : string -> string -> string list -> (string, string) result
 
 val session_path_exists : string -> string -> string list -> (string, string) result
+
+val reload_reference_tree : string -> (string, string) result

--- a/src/vyconf_config.ml
+++ b/src/vyconf_config.ml
@@ -5,6 +5,7 @@ type t = {
     data_dir: string;
     program_dir: string;
     config_dir: string;
+    reftree_dir: string;
     primary_config: string;
     fallback_config: string;
     reference_tree: string;
@@ -22,6 +23,7 @@ let empty_config = {
     data_dir = "";
     program_dir = "";
     config_dir = "";
+    reftree_dir = "";
     primary_config = "";
     fallback_config = "";
     reference_tree = "";
@@ -60,6 +62,7 @@ let load filename =
             let conf = {conf with app_name = mandatory_field conf_toml "appliance" "name"} in
             let conf = {conf with data_dir = mandatory_field conf_toml "appliance" "data_dir"} in
             let conf = {conf with config_dir = mandatory_field conf_toml "appliance" "config_dir"} in
+            let conf = {conf with reftree_dir = mandatory_field conf_toml "appliance" "reftree_dir"} in
             let conf = {conf with program_dir = mandatory_field conf_toml "appliance" "program_dir"} in
             let conf = {conf with primary_config = mandatory_field conf_toml "appliance" "primary_config"} in
             let conf = {conf with fallback_config = mandatory_field conf_toml "appliance" "fallback_config"} in

--- a/src/vyconf_config.mli
+++ b/src/vyconf_config.mli
@@ -3,6 +3,7 @@ type t = {
     data_dir: string;
     program_dir: string;
     config_dir: string;
+    reftree_dir: string;
     primary_config: string;
     fallback_config: string;
     reference_tree: string;

--- a/src/vyconf_pbt.mli
+++ b/src/vyconf_pbt.mli
@@ -120,6 +120,10 @@ type request_enter_configuration_mode = {
 
 type request_exit_configuration_mode = unit
 
+type request_reload_reftree = {
+  on_behalf_of : int32 option;
+}
+
 type request =
   | Status
   | Setup_session of request_setup_session
@@ -143,6 +147,7 @@ type request =
   | Exit_configure
   | Validate of request_validate
   | Teardown of request_teardown
+  | Reload_reftree of request_reload_reftree
 
 type request_envelope = {
   token : string option;
@@ -324,6 +329,12 @@ val default_request_enter_configuration_mode :
 val default_request_exit_configuration_mode : unit
 (** [default_request_exit_configuration_mode ()] is the default value for type [request_exit_configuration_mode] *)
 
+val default_request_reload_reftree : 
+  ?on_behalf_of:int32 option ->
+  unit ->
+  request_reload_reftree
+(** [default_request_reload_reftree ()] is the default value for type [request_reload_reftree] *)
+
 val default_request : unit -> request
 (** [default_request ()] is the default value for type [request] *)
 
@@ -424,6 +435,9 @@ val pp_request_enter_configuration_mode : Format.formatter -> request_enter_conf
 val pp_request_exit_configuration_mode : Format.formatter -> request_exit_configuration_mode -> unit 
 (** [pp_request_exit_configuration_mode v] formats v *)
 
+val pp_request_reload_reftree : Format.formatter -> request_reload_reftree -> unit 
+(** [pp_request_reload_reftree v] formats v *)
+
 val pp_request : Format.formatter -> request -> unit 
 (** [pp_request v] formats v *)
 
@@ -514,6 +528,9 @@ val encode_pb_request_enter_configuration_mode : request_enter_configuration_mod
 val encode_pb_request_exit_configuration_mode : request_exit_configuration_mode -> Pbrt.Encoder.t -> unit
 (** [encode_pb_request_exit_configuration_mode v encoder] encodes [v] with the given [encoder] *)
 
+val encode_pb_request_reload_reftree : request_reload_reftree -> Pbrt.Encoder.t -> unit
+(** [encode_pb_request_reload_reftree v encoder] encodes [v] with the given [encoder] *)
+
 val encode_pb_request : request -> Pbrt.Encoder.t -> unit
 (** [encode_pb_request v encoder] encodes [v] with the given [encoder] *)
 
@@ -603,6 +620,9 @@ val decode_pb_request_enter_configuration_mode : Pbrt.Decoder.t -> request_enter
 
 val decode_pb_request_exit_configuration_mode : Pbrt.Decoder.t -> request_exit_configuration_mode
 (** [decode_pb_request_exit_configuration_mode decoder] decodes a [request_exit_configuration_mode] binary value from [decoder] *)
+
+val decode_pb_request_reload_reftree : Pbrt.Decoder.t -> request_reload_reftree
+(** [decode_pb_request_reload_reftree decoder] decodes a [request_reload_reftree] binary value from [decoder] *)
 
 val decode_pb_request : Pbrt.Decoder.t -> request
 (** [decode_pb_request decoder] decodes a [request] binary value from [decoder] *)

--- a/src/vyconfd.ml
+++ b/src/vyconfd.ml
@@ -220,7 +220,7 @@ let read_reference_tree file =
 let make_world config dirs =
     let open Session in
     (* the reference_tree json file is generated at vyos-1x build time *)
-    let reftree = read_reference_tree (FP.concat config.config_dir config.reference_tree) in
+    let reftree = read_reference_tree (FP.concat config.reftree_dir config.reference_tree) in
     let running_config = CT.make "" in
     {running_config=running_config; reference_tree=reftree; vyconf_config=config; dirs=dirs}
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Make world fields config tree and reference tree mutable for runtime/session updates.
Add request reload_reftree.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
