### PR TITLE
T7121: Set up communication vyconfd <-> vyos-configd

### DIFF
--- a/data/dune
+++ b/data/dune
@@ -1,3 +1,3 @@
 (install
- (files vyconfd.conf vyconf.proto)
+ (files vyconfd.conf vyconf.proto vycall.proto)
  (section share))

--- a/data/vycall.proto
+++ b/data/vycall.proto
@@ -1,0 +1,27 @@
+message Status {
+    required bool success = 1;
+    required string out = 2;
+}
+
+message Call {
+    required string script_name = 1;
+    optional string tag_value = 2;
+    optional string arg_value = 3;
+    optional Status reply = 4;
+}
+
+message Commit {
+    required string session_id = 1;
+    // optional explicit load;
+    // otherwise, session configs are loaded from cached internal
+    // representation, specified by session id value
+    optional string named_active = 2;
+    optional string named_proposed = 3;
+    //
+    required bool dry_run = 4;
+    required bool atomic = 5;
+    required bool background = 6;
+
+    optional Status init = 7;
+    repeated Call calls = 8;
+}

--- a/data/vyconfd.conf
+++ b/data/vyconfd.conf
@@ -6,6 +6,7 @@ data_dir = "/usr/share/vyos/vyconf"
 program_dir = "/usr/libexec/vyos"
 config_dir = "/usr/libexec/vyos/vyconf/config"
 reftree_dir = "/usr/libexec/vyos/vyconf/reftree"
+session_dir = "/usr/libexec/vyos/vyconf/session"
 
 # paths relative to config_dir
 primary_config = "config.boot"
@@ -13,6 +14,12 @@ fallback_config = "config.failsafe"
 
 # paths relative to reftree_dir
 reference_tree = "reftree.cache"
+
+# paths relative to session_dir
+running_cache = "running_cache"
+session_cache = "session_cache"
+
+commitd_socket = "/var/run/vyos-commitd.sock"
 
 [vyconf]
 

--- a/src/commit.ml
+++ b/src/commit.ml
@@ -155,6 +155,18 @@ let calculate_priority_lists rt at wt =
     let cs_del, cs_add = legacy_order del_tree cs_del' cs_add' in
     List.rev (CS.elements cs_del), CS.elements cs_add
 
+let commit_store c_data =
+    let out =
+        let func acc nd =
+            match nd.reply with
+            | None -> acc ^ "\n"
+            | Some r ->
+                match r.success with
+                | true -> acc ^ "\n"
+                | false -> acc ^ "\n" ^ r.out
+        in List.fold_left func "" c_data.node_list
+    in print_endline out
+
 let show_commit_data at wt =
     let vc =
         Startup.load_daemon_config Defaults.defaults.config_file in

--- a/src/commit.mli
+++ b/src/commit.mli
@@ -1,2 +1,30 @@
+type status = {
+  success : bool;
+  out : string;
+}
+
+type node_data = {
+    script_name: string option;
+    priority: int;
+    tag_value: string option;
+    arg_value: string option;
+    path: string list;
+    reply: status option;
+} [@@deriving yojson]
+
+type commit_data = {
+    session_id: string;
+    named_active : string option;
+    named_proposed : string option;
+    dry_run: bool;
+    atomic: bool;
+    background: bool;
+    init: status option;
+    node_list: node_data list;
+} [@@deriving yojson]
+
+val default_node_data : node_data
+
+val default_commit_data : commit_data
 
 val show_commit_data : Vyos1x.Config_tree.t -> Vyos1x.Config_tree.t -> string

--- a/src/commit.mli
+++ b/src/commit.mli
@@ -27,4 +27,8 @@ val default_node_data : node_data
 
 val default_commit_data : commit_data
 
+val calculate_priority_lists : Vyos1x.Reference_tree.t -> Vyos1x.Config_tree.t -> Vyos1x.Config_tree.t -> node_data list * node_data list
+
+val commit_store : commit_data -> unit
+
 val show_commit_data : Vyos1x.Config_tree.t -> Vyos1x.Config_tree.t -> string

--- a/src/commit.mli
+++ b/src/commit.mli
@@ -4,7 +4,7 @@ type status = {
 }
 
 type node_data = {
-    script_name: string option;
+    script_name: string;
     priority: int;
     tag_value: string option;
     arg_value: string option;

--- a/src/commit.mli
+++ b/src/commit.mli
@@ -1,3 +1,5 @@
+type tree_source = DELETE | ADD
+
 type status = {
   success : bool;
   out : string;
@@ -9,8 +11,9 @@ type node_data = {
     tag_value: string option;
     arg_value: string option;
     path: string list;
+    source: tree_source;
     reply: status option;
-} [@@deriving yojson]
+} [@@deriving to_yojson]
 
 type commit_data = {
     session_id: string;
@@ -21,7 +24,7 @@ type commit_data = {
     background: bool;
     init: status option;
     node_list: node_data list;
-} [@@deriving yojson]
+} [@@deriving to_yojson]
 
 val default_node_data : node_data
 

--- a/src/dune
+++ b/src/dune
@@ -22,6 +22,19 @@
             yojson ppx_deriving.show ppx_deriving_yojson)
  (preprocess (pps lwt_ppx ppx_deriving.show ppx_deriving_yojson)))
 
+(library
+ (name vycall_message)
+ (public_name vyconf.vycall-message)
+ (modules vycall_pbt)
+ (libraries ocaml-protoc))
+
+(library
+ (name commitd_client)
+ (public_name vyconf.vycall-client)
+ (modules vycall_client)
+ (libraries vyos1x-config vyconfd_config vycall_message lwt lwt.unix lwt_log lwt_ppx ocplib-endian)
+ (preprocess (pps lwt_ppx)))
+
 (executable
  (name vyconfd)
  (public_name vyconfd)

--- a/src/dune
+++ b/src/dune
@@ -50,7 +50,6 @@
  (preprocess (pps lwt_ppx)))
 
 (rule
- (alias protoc)
  (mode promote)
  (targets vyconf_pbt.ml vyconf_pbt.mli)
  (action
@@ -60,6 +59,17 @@
     (run ocaml-protoc --ml_out src data/vyconf.proto)
     (run mv src/vyconf.ml src/vyconf_pbt.ml)
     (run mv src/vyconf.mli src/vyconf_pbt.mli)))))
+
+(rule
+ (mode promote)
+ (targets vycall_pbt.ml vycall_pbt.mli)
+ (action
+  (chdir
+   %{project_root}
+   (progn
+    (run ocaml-protoc --ml_out src data/vycall.proto)
+    (run mv src/vycall.ml src/vycall_pbt.ml)
+    (run mv src/vycall.mli src/vycall_pbt.mli)))))
 
 (library
  (name vyos1x_adapter)

--- a/src/vycall_client.ml
+++ b/src/vycall_client.ml
@@ -1,0 +1,124 @@
+(* send commit data to Python commit daemon *)
+
+open Vycall_message.Vycall_pbt
+open Vyconfd_config.Commit
+
+module CT = Vyos1x.Config_tree
+module IC = Vyos1x.Internal.Make(CT)
+module ST = Vyconfd_config.Startup
+module DF = Vyconfd_config.Defaults
+module FP = FilePath
+
+type t = {
+    ic: Lwt_io.input Lwt_io.channel;
+    oc: Lwt_io.output Lwt_io.channel;
+}
+
+(* explicit translation between commit data and commit protobuf
+ * to keep the commit data opaque to protobuf message definition.
+ * The commit daemon updates the (subset of) commit data with
+ * results of script execution in init/reply fields.
+ *)
+let node_data_to_call nd =
+    { script_name = nd.script_name;
+      tag_value = nd.tag_value;
+      arg_value = nd.arg_value;
+      reply = None
+    }
+
+let call_to_node_data ((c: call), (nd: node_data)) =
+    match c.reply with
+    | None -> nd
+    | Some r -> { nd with reply = Some { success = r.success; out = r.out }}
+
+let commit_data_to_commit_proto cd =
+    { session_id = cd.session_id;
+      named_active = cd.named_active;
+      named_proposed = cd.named_proposed;
+      dry_run = cd.dry_run;
+      atomic = cd.atomic;
+      background = cd.background;
+      init = None;
+      calls = List.map node_data_to_call cd.node_list;
+    }
+
+let commit_proto_to_commit_data (c: commit) (cd: commit_data) =
+    match c.init with
+    | None -> cd
+    | Some i ->
+        { cd with init = Some { success = i.success; out = i.out };
+          node_list =
+              List.map call_to_node_data (List.combine c.calls cd.node_list);
+        }
+
+(* read/write message from/to socket *)
+let call_write oc msg =
+    let length = Bytes.length msg in
+    let length' = Int32.of_int length in
+    if length' < 0l then failwith (Printf.sprintf "Bad message length: %d" length) else
+    let header = Bytes.create 4 in
+    let () = EndianBytes.BigEndian.set_int32 header 0 length' in
+    let%lwt () = Lwt_io.write_from_exactly oc header 0 4 in
+    Lwt_io.write_from_exactly oc msg 0 length
+
+let call_read ic =
+    let header = Bytes.create 4 in
+    let%lwt () = Lwt_io.read_into_exactly ic header 0 4 in
+    let length = EndianBytes.BigEndian.get_int32 header 0 |> Int32.to_int in
+    if length < 0 then failwith (Printf.sprintf "Bad message length: %d" length) else
+    let buffer = Bytes.create length in
+    let%lwt () = Lwt_io.read_into_exactly ic buffer 0 length in
+    Lwt.return buffer
+
+(* encode/decode commit data *)
+let do_call client request =
+    let enc = Pbrt.Encoder.create () in
+    let () = encode_pb_commit request enc in
+    let msg = Pbrt.Encoder.to_bytes enc in
+    let%lwt () = call_write client.oc msg in
+    let%lwt resp = call_read client.ic in
+    decode_pb_commit (Pbrt.Decoder.of_bytes resp) |> Lwt.return
+
+(* socket management and commit callback *)
+let create sockfile =
+    let open Lwt_unix in
+    let sock = socket PF_UNIX SOCK_STREAM 0 in
+    let%lwt () = connect sock (ADDR_UNIX sockfile) in
+    let ic = Lwt_io.of_fd ~mode:Lwt_io.Input sock in
+    let oc = Lwt_io.of_fd ~mode:Lwt_io.Output sock in
+    Lwt.return { ic=ic; oc=oc; }
+
+let update session_data =
+    Lwt.return (commit_store session_data)
+
+let do_commit session_data =
+    let session = commit_data_to_commit_proto session_data in
+    let run () =
+        let sockfile = "/run/vyos-commitd.sock" in
+        let%lwt client = create sockfile in
+        let%lwt resp = do_call client session in
+        let%lwt () = Lwt_io.close client.oc in
+        update (commit_proto_to_commit_data resp session_data)
+    in Lwt_main.run @@ run ()
+
+(* test function *)
+let test_commit at wt =
+    let vc =
+        ST.load_daemon_config DF.defaults.config_file in
+    let () =
+        IC.write_internal at (FP.concat vc.session_dir vc.running_cache) in
+    let () =
+        IC.write_internal wt (FP.concat vc.session_dir vc.session_cache) in
+    let rt_opt =
+        ST.read_reference_tree (FP.concat vc.reftree_dir vc.reference_tree)
+    in
+    match rt_opt with
+    | Error msg -> print_endline msg
+    | Ok rt ->
+        let del_list, add_list =
+            calculate_priority_lists rt at wt
+        in
+        let commit_session =
+            { default_commit_data with node_list = del_list @ add_list }
+        in
+        do_commit commit_session

--- a/src/vycall_client.mli
+++ b/src/vycall_client.mli
@@ -1,0 +1,1 @@
+val test_commit : Vyos1x.Config_tree.t -> Vyos1x.Config_tree.t -> unit

--- a/src/vycall_pbt.ml
+++ b/src/vycall_pbt.ml
@@ -1,0 +1,349 @@
+[@@@ocaml.warning "-27-30-39-44"]
+
+type status = {
+  success : bool;
+  out : string;
+}
+
+type call = {
+  script_name : string;
+  tag_value : string option;
+  arg_value : string option;
+  reply : status option;
+}
+
+type commit = {
+  session_id : string;
+  named_active : string option;
+  named_proposed : string option;
+  dry_run : bool;
+  atomic : bool;
+  background : bool;
+  init : status option;
+  calls : call list;
+}
+
+let rec default_status 
+  ?success:((success:bool) = false)
+  ?out:((out:string) = "")
+  () : status  = {
+  success;
+  out;
+}
+
+let rec default_call 
+  ?script_name:((script_name:string) = "")
+  ?tag_value:((tag_value:string option) = None)
+  ?arg_value:((arg_value:string option) = None)
+  ?reply:((reply:status option) = None)
+  () : call  = {
+  script_name;
+  tag_value;
+  arg_value;
+  reply;
+}
+
+let rec default_commit 
+  ?session_id:((session_id:string) = "")
+  ?named_active:((named_active:string option) = None)
+  ?named_proposed:((named_proposed:string option) = None)
+  ?dry_run:((dry_run:bool) = false)
+  ?atomic:((atomic:bool) = false)
+  ?background:((background:bool) = false)
+  ?init:((init:status option) = None)
+  ?calls:((calls:call list) = [])
+  () : commit  = {
+  session_id;
+  named_active;
+  named_proposed;
+  dry_run;
+  atomic;
+  background;
+  init;
+  calls;
+}
+
+type status_mutable = {
+  mutable success : bool;
+  mutable out : string;
+}
+
+let default_status_mutable () : status_mutable = {
+  success = false;
+  out = "";
+}
+
+type call_mutable = {
+  mutable script_name : string;
+  mutable tag_value : string option;
+  mutable arg_value : string option;
+  mutable reply : status option;
+}
+
+let default_call_mutable () : call_mutable = {
+  script_name = "";
+  tag_value = None;
+  arg_value = None;
+  reply = None;
+}
+
+type commit_mutable = {
+  mutable session_id : string;
+  mutable named_active : string option;
+  mutable named_proposed : string option;
+  mutable dry_run : bool;
+  mutable atomic : bool;
+  mutable background : bool;
+  mutable init : status option;
+  mutable calls : call list;
+}
+
+let default_commit_mutable () : commit_mutable = {
+  session_id = "";
+  named_active = None;
+  named_proposed = None;
+  dry_run = false;
+  atomic = false;
+  background = false;
+  init = None;
+  calls = [];
+}
+
+[@@@ocaml.warning "-27-30-39"]
+
+(** {2 Formatters} *)
+
+let rec pp_status fmt (v:status) = 
+  let pp_i fmt () =
+    Pbrt.Pp.pp_record_field ~first:true "success" Pbrt.Pp.pp_bool fmt v.success;
+    Pbrt.Pp.pp_record_field ~first:false "out" Pbrt.Pp.pp_string fmt v.out;
+  in
+  Pbrt.Pp.pp_brk pp_i fmt ()
+
+let rec pp_call fmt (v:call) = 
+  let pp_i fmt () =
+    Pbrt.Pp.pp_record_field ~first:true "script_name" Pbrt.Pp.pp_string fmt v.script_name;
+    Pbrt.Pp.pp_record_field ~first:false "tag_value" (Pbrt.Pp.pp_option Pbrt.Pp.pp_string) fmt v.tag_value;
+    Pbrt.Pp.pp_record_field ~first:false "arg_value" (Pbrt.Pp.pp_option Pbrt.Pp.pp_string) fmt v.arg_value;
+    Pbrt.Pp.pp_record_field ~first:false "reply" (Pbrt.Pp.pp_option pp_status) fmt v.reply;
+  in
+  Pbrt.Pp.pp_brk pp_i fmt ()
+
+let rec pp_commit fmt (v:commit) = 
+  let pp_i fmt () =
+    Pbrt.Pp.pp_record_field ~first:true "session_id" Pbrt.Pp.pp_string fmt v.session_id;
+    Pbrt.Pp.pp_record_field ~first:false "named_active" (Pbrt.Pp.pp_option Pbrt.Pp.pp_string) fmt v.named_active;
+    Pbrt.Pp.pp_record_field ~first:false "named_proposed" (Pbrt.Pp.pp_option Pbrt.Pp.pp_string) fmt v.named_proposed;
+    Pbrt.Pp.pp_record_field ~first:false "dry_run" Pbrt.Pp.pp_bool fmt v.dry_run;
+    Pbrt.Pp.pp_record_field ~first:false "atomic" Pbrt.Pp.pp_bool fmt v.atomic;
+    Pbrt.Pp.pp_record_field ~first:false "background" Pbrt.Pp.pp_bool fmt v.background;
+    Pbrt.Pp.pp_record_field ~first:false "init" (Pbrt.Pp.pp_option pp_status) fmt v.init;
+    Pbrt.Pp.pp_record_field ~first:false "calls" (Pbrt.Pp.pp_list pp_call) fmt v.calls;
+  in
+  Pbrt.Pp.pp_brk pp_i fmt ()
+
+[@@@ocaml.warning "-27-30-39"]
+
+(** {2 Protobuf Encoding} *)
+
+let rec encode_pb_status (v:status) encoder = 
+  Pbrt.Encoder.bool v.success encoder;
+  Pbrt.Encoder.key 1 Pbrt.Varint encoder; 
+  Pbrt.Encoder.string v.out encoder;
+  Pbrt.Encoder.key 2 Pbrt.Bytes encoder; 
+  ()
+
+let rec encode_pb_call (v:call) encoder = 
+  Pbrt.Encoder.string v.script_name encoder;
+  Pbrt.Encoder.key 1 Pbrt.Bytes encoder; 
+  begin match v.tag_value with
+  | Some x -> 
+    Pbrt.Encoder.string x encoder;
+    Pbrt.Encoder.key 2 Pbrt.Bytes encoder; 
+  | None -> ();
+  end;
+  begin match v.arg_value with
+  | Some x -> 
+    Pbrt.Encoder.string x encoder;
+    Pbrt.Encoder.key 3 Pbrt.Bytes encoder; 
+  | None -> ();
+  end;
+  begin match v.reply with
+  | Some x -> 
+    Pbrt.Encoder.nested encode_pb_status x encoder;
+    Pbrt.Encoder.key 4 Pbrt.Bytes encoder; 
+  | None -> ();
+  end;
+  ()
+
+let rec encode_pb_commit (v:commit) encoder = 
+  Pbrt.Encoder.string v.session_id encoder;
+  Pbrt.Encoder.key 1 Pbrt.Bytes encoder; 
+  begin match v.named_active with
+  | Some x -> 
+    Pbrt.Encoder.string x encoder;
+    Pbrt.Encoder.key 2 Pbrt.Bytes encoder; 
+  | None -> ();
+  end;
+  begin match v.named_proposed with
+  | Some x -> 
+    Pbrt.Encoder.string x encoder;
+    Pbrt.Encoder.key 3 Pbrt.Bytes encoder; 
+  | None -> ();
+  end;
+  Pbrt.Encoder.bool v.dry_run encoder;
+  Pbrt.Encoder.key 4 Pbrt.Varint encoder; 
+  Pbrt.Encoder.bool v.atomic encoder;
+  Pbrt.Encoder.key 5 Pbrt.Varint encoder; 
+  Pbrt.Encoder.bool v.background encoder;
+  Pbrt.Encoder.key 6 Pbrt.Varint encoder; 
+  begin match v.init with
+  | Some x -> 
+    Pbrt.Encoder.nested encode_pb_status x encoder;
+    Pbrt.Encoder.key 7 Pbrt.Bytes encoder; 
+  | None -> ();
+  end;
+  Pbrt.List_util.rev_iter_with (fun x encoder -> 
+    Pbrt.Encoder.nested encode_pb_call x encoder;
+    Pbrt.Encoder.key 8 Pbrt.Bytes encoder; 
+  ) v.calls encoder;
+  ()
+
+[@@@ocaml.warning "-27-30-39"]
+
+(** {2 Protobuf Decoding} *)
+
+let rec decode_pb_status d =
+  let v = default_status_mutable () in
+  let continue__= ref true in
+  let out_is_set = ref false in
+  let success_is_set = ref false in
+  while !continue__ do
+    match Pbrt.Decoder.key d with
+    | None -> (
+    ); continue__ := false
+    | Some (1, Pbrt.Varint) -> begin
+      v.success <- Pbrt.Decoder.bool d; success_is_set := true;
+    end
+    | Some (1, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(status), field(1)" pk
+    | Some (2, Pbrt.Bytes) -> begin
+      v.out <- Pbrt.Decoder.string d; out_is_set := true;
+    end
+    | Some (2, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(status), field(2)" pk
+    | Some (_, payload_kind) -> Pbrt.Decoder.skip d payload_kind
+  done;
+  begin if not !out_is_set then Pbrt.Decoder.missing_field "out" end;
+  begin if not !success_is_set then Pbrt.Decoder.missing_field "success" end;
+  ({
+    success = v.success;
+    out = v.out;
+  } : status)
+
+let rec decode_pb_call d =
+  let v = default_call_mutable () in
+  let continue__= ref true in
+  let script_name_is_set = ref false in
+  while !continue__ do
+    match Pbrt.Decoder.key d with
+    | None -> (
+    ); continue__ := false
+    | Some (1, Pbrt.Bytes) -> begin
+      v.script_name <- Pbrt.Decoder.string d; script_name_is_set := true;
+    end
+    | Some (1, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(call), field(1)" pk
+    | Some (2, Pbrt.Bytes) -> begin
+      v.tag_value <- Some (Pbrt.Decoder.string d);
+    end
+    | Some (2, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(call), field(2)" pk
+    | Some (3, Pbrt.Bytes) -> begin
+      v.arg_value <- Some (Pbrt.Decoder.string d);
+    end
+    | Some (3, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(call), field(3)" pk
+    | Some (4, Pbrt.Bytes) -> begin
+      v.reply <- Some (decode_pb_status (Pbrt.Decoder.nested d));
+    end
+    | Some (4, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(call), field(4)" pk
+    | Some (_, payload_kind) -> Pbrt.Decoder.skip d payload_kind
+  done;
+  begin if not !script_name_is_set then Pbrt.Decoder.missing_field "script_name" end;
+  ({
+    script_name = v.script_name;
+    tag_value = v.tag_value;
+    arg_value = v.arg_value;
+    reply = v.reply;
+  } : call)
+
+let rec decode_pb_commit d =
+  let v = default_commit_mutable () in
+  let continue__= ref true in
+  let background_is_set = ref false in
+  let atomic_is_set = ref false in
+  let dry_run_is_set = ref false in
+  let session_id_is_set = ref false in
+  while !continue__ do
+    match Pbrt.Decoder.key d with
+    | None -> (
+      v.calls <- List.rev v.calls;
+    ); continue__ := false
+    | Some (1, Pbrt.Bytes) -> begin
+      v.session_id <- Pbrt.Decoder.string d; session_id_is_set := true;
+    end
+    | Some (1, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(commit), field(1)" pk
+    | Some (2, Pbrt.Bytes) -> begin
+      v.named_active <- Some (Pbrt.Decoder.string d);
+    end
+    | Some (2, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(commit), field(2)" pk
+    | Some (3, Pbrt.Bytes) -> begin
+      v.named_proposed <- Some (Pbrt.Decoder.string d);
+    end
+    | Some (3, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(commit), field(3)" pk
+    | Some (4, Pbrt.Varint) -> begin
+      v.dry_run <- Pbrt.Decoder.bool d; dry_run_is_set := true;
+    end
+    | Some (4, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(commit), field(4)" pk
+    | Some (5, Pbrt.Varint) -> begin
+      v.atomic <- Pbrt.Decoder.bool d; atomic_is_set := true;
+    end
+    | Some (5, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(commit), field(5)" pk
+    | Some (6, Pbrt.Varint) -> begin
+      v.background <- Pbrt.Decoder.bool d; background_is_set := true;
+    end
+    | Some (6, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(commit), field(6)" pk
+    | Some (7, Pbrt.Bytes) -> begin
+      v.init <- Some (decode_pb_status (Pbrt.Decoder.nested d));
+    end
+    | Some (7, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(commit), field(7)" pk
+    | Some (8, Pbrt.Bytes) -> begin
+      v.calls <- (decode_pb_call (Pbrt.Decoder.nested d)) :: v.calls;
+    end
+    | Some (8, pk) -> 
+      Pbrt.Decoder.unexpected_payload "Message(commit), field(8)" pk
+    | Some (_, payload_kind) -> Pbrt.Decoder.skip d payload_kind
+  done;
+  begin if not !background_is_set then Pbrt.Decoder.missing_field "background" end;
+  begin if not !atomic_is_set then Pbrt.Decoder.missing_field "atomic" end;
+  begin if not !dry_run_is_set then Pbrt.Decoder.missing_field "dry_run" end;
+  begin if not !session_id_is_set then Pbrt.Decoder.missing_field "session_id" end;
+  ({
+    session_id = v.session_id;
+    named_active = v.named_active;
+    named_proposed = v.named_proposed;
+    dry_run = v.dry_run;
+    atomic = v.atomic;
+    background = v.background;
+    init = v.init;
+    calls = v.calls;
+  } : commit)

--- a/src/vycall_pbt.mli
+++ b/src/vycall_pbt.mli
@@ -1,0 +1,99 @@
+
+(** Code for vycall.proto *)
+
+(* generated from "data/vycall.proto", do not edit *)
+
+
+
+(** {2 Types} *)
+
+type status = {
+  success : bool;
+  out : string;
+}
+
+type call = {
+  script_name : string;
+  tag_value : string option;
+  arg_value : string option;
+  reply : status option;
+}
+
+type commit = {
+  session_id : string;
+  named_active : string option;
+  named_proposed : string option;
+  dry_run : bool;
+  atomic : bool;
+  background : bool;
+  init : status option;
+  calls : call list;
+}
+
+
+(** {2 Basic values} *)
+
+val default_status : 
+  ?success:bool ->
+  ?out:string ->
+  unit ->
+  status
+(** [default_status ()] is the default value for type [status] *)
+
+val default_call : 
+  ?script_name:string ->
+  ?tag_value:string option ->
+  ?arg_value:string option ->
+  ?reply:status option ->
+  unit ->
+  call
+(** [default_call ()] is the default value for type [call] *)
+
+val default_commit : 
+  ?session_id:string ->
+  ?named_active:string option ->
+  ?named_proposed:string option ->
+  ?dry_run:bool ->
+  ?atomic:bool ->
+  ?background:bool ->
+  ?init:status option ->
+  ?calls:call list ->
+  unit ->
+  commit
+(** [default_commit ()] is the default value for type [commit] *)
+
+
+(** {2 Formatters} *)
+
+val pp_status : Format.formatter -> status -> unit 
+(** [pp_status v] formats v *)
+
+val pp_call : Format.formatter -> call -> unit 
+(** [pp_call v] formats v *)
+
+val pp_commit : Format.formatter -> commit -> unit 
+(** [pp_commit v] formats v *)
+
+
+(** {2 Protobuf Encoding} *)
+
+val encode_pb_status : status -> Pbrt.Encoder.t -> unit
+(** [encode_pb_status v encoder] encodes [v] with the given [encoder] *)
+
+val encode_pb_call : call -> Pbrt.Encoder.t -> unit
+(** [encode_pb_call v encoder] encodes [v] with the given [encoder] *)
+
+val encode_pb_commit : commit -> Pbrt.Encoder.t -> unit
+(** [encode_pb_commit v encoder] encodes [v] with the given [encoder] *)
+
+
+(** {2 Protobuf Decoding} *)
+
+val decode_pb_status : Pbrt.Decoder.t -> status
+(** [decode_pb_status decoder] decodes a [status] binary value from [decoder] *)
+
+val decode_pb_call : Pbrt.Decoder.t -> call
+(** [decode_pb_call decoder] decodes a [call] binary value from [decoder] *)
+
+val decode_pb_commit : Pbrt.Decoder.t -> commit
+(** [decode_pb_commit decoder] decodes a [commit] binary value from [decoder] *)

--- a/src/vyconf_config.ml
+++ b/src/vyconf_config.ml
@@ -6,9 +6,12 @@ type t = {
     program_dir: string;
     config_dir: string;
     reftree_dir: string;
+    session_dir: string;
     primary_config: string;
     fallback_config: string;
     reference_tree: string;
+    running_cache: string;
+    session_cache: string;
     socket: string;
     pid_file: string;
     log_file: string option;
@@ -24,9 +27,12 @@ let empty_config = {
     program_dir = "";
     config_dir = "";
     reftree_dir = "";
+    session_dir = "";
     primary_config = "";
     fallback_config = "";
     reference_tree = "";
+    running_cache = "";
+    session_cache = "";
     socket = "";
     pid_file = "";
     log_file = None;
@@ -63,10 +69,13 @@ let load filename =
             let conf = {conf with data_dir = mandatory_field conf_toml "appliance" "data_dir"} in
             let conf = {conf with config_dir = mandatory_field conf_toml "appliance" "config_dir"} in
             let conf = {conf with reftree_dir = mandatory_field conf_toml "appliance" "reftree_dir"} in
+            let conf = {conf with session_dir = mandatory_field conf_toml "appliance" "session_dir"} in
             let conf = {conf with program_dir = mandatory_field conf_toml "appliance" "program_dir"} in
             let conf = {conf with primary_config = mandatory_field conf_toml "appliance" "primary_config"} in
             let conf = {conf with fallback_config = mandatory_field conf_toml "appliance" "fallback_config"} in
             let conf = {conf with reference_tree = mandatory_field conf_toml "appliance" "reference_tree"} in
+            let conf = {conf with running_cache = mandatory_field conf_toml "appliance" "running_cache"} in
+            let conf = {conf with session_cache = mandatory_field conf_toml "appliance" "session_cache"} in
             (* Optional fields *)
             let conf = {conf with pid_file = optional_field defaults.pid_file conf_toml "vyconf" "pid_file"} in
             let conf = {conf with socket = optional_field defaults.socket conf_toml "vyconf" "socket"} in

--- a/src/vyconf_config.mli
+++ b/src/vyconf_config.mli
@@ -4,9 +4,12 @@ type t = {
     program_dir: string;
     config_dir: string;
     reftree_dir: string;
+    session_dir: string;
     primary_config: string;
     fallback_config: string;
     reference_tree: string;
+    running_cache: string;
+    session_cache: string;
     socket: string;
     pid_file: string;
     log_file: string option;


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Define protobuf message definitions and vyos-commitd client operations.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
