### PR TITLE
T7321: Replace legacy operations in configsession.py with vyconf client operations

### DIFF
--- a/data/vyconf.proto
+++ b/data/vyconf.proto
@@ -148,6 +148,7 @@ message Request {
     Validate validate = 21;
     Teardown teardown = 22;
     ReloadReftree reload_reftree = 23;
+    Load load = 24;
   }
 }
 

--- a/data/vyconf.proto
+++ b/data/vyconf.proto
@@ -34,6 +34,10 @@ message Request {
     repeated string Path = 1;
   }
 
+  message Discard {
+    optional int32 dummy = 1;
+  }
+
   message Rename {
     repeated string EditLevel = 1;
     required string From = 2;
@@ -149,6 +153,7 @@ message Request {
     Teardown teardown = 22;
     ReloadReftree reload_reftree = 23;
     Load load = 24;
+    Discard discard = 25;
   }
 }
 

--- a/data/vyconf.proto
+++ b/data/vyconf.proto
@@ -9,7 +9,7 @@ message Request {
     OutJSON = 1;
   }
 
-  message Status {
+  message Prompt {
   }
 
   message SetupSession {
@@ -125,7 +125,7 @@ message Request {
 
 
   oneof msg {
-    Status status = 1;
+    Prompt prompt = 1;
     SetupSession setup_session = 2;
     Set set = 3;
     Delete delete = 4;
@@ -156,7 +156,7 @@ message RequestEnvelope {
     required Request request = 2;
 }
 
-enum Status {
+enum Errnum {
   SUCCESS = 0;
   FAIL = 1;
   INVALID_PATH = 2;
@@ -169,7 +169,7 @@ enum Status {
 }
 
 message Response {
-  required Status status = 1;
+  required Errnum status = 1;
   optional string output = 2;
   optional string error = 3;
   optional string warning = 4;

--- a/data/vyconf.proto
+++ b/data/vyconf.proto
@@ -38,6 +38,10 @@ message Request {
     optional int32 dummy = 1;
   }
 
+  message SessionChanged {
+    optional int32 dummy = 1;
+  }
+
   message Rename {
     repeated string EditLevel = 1;
     required string From = 2;
@@ -154,6 +158,7 @@ message Request {
     ReloadReftree reload_reftree = 23;
     Load load = 24;
     Discard discard = 25;
+    SessionChanged session_changed = 26;
   }
 }
 

--- a/src/session.ml
+++ b/src/session.ml
@@ -95,9 +95,12 @@ let set w s path =
     let value_behaviour = if RT.is_multi w.reference_tree refpath then CT.AddValue else CT.ReplaceValue in
     let op = CfgSet (path, value, value_behaviour) in
     let config =
-        apply_cfg_op op s.proposed_config |>
-        (fun c -> RT.set_tag_data w.reference_tree c path) |>
-        (fun c -> RT.set_leaf_data w.reference_tree c path)
+        try
+            apply_cfg_op op s.proposed_config |>
+            (fun c -> RT.set_tag_data w.reference_tree c path) |>
+            (fun c -> RT.set_leaf_data w.reference_tree c path)
+        with CT.Useless_set ->
+            raise (Session_error (Printf.sprintf "Useless set, path: %s" (string_of_op op)))
     in
     {s with proposed_config=config; changeset=(op :: s.changeset)}
 

--- a/src/session.ml
+++ b/src/session.ml
@@ -1,4 +1,5 @@
 module CT = Vyos1x.Config_tree
+module CD = Vyos1x.Config_diff
 module VT = Vyos1x.Vytree
 module RT = Vyos1x.Reference_tree
 module D = Directories
@@ -109,6 +110,15 @@ let delete w s path =
 
 let discard w s =
     {s with proposed_config=w.running_config}
+
+let session_changed w s =
+    (* structural equality test requires consistent ordering, which is
+     * practised, but may be unreliable; test actual difference
+     *)
+    let diff = CD.diff_tree [] w.running_config s.proposed_config in
+    let add_tree = CT.get_subtree diff ["add"] in
+    let del_tree = CT.get_subtree diff ["del"] in
+    (del_tree <> CT.default) || (add_tree <> CT.default)
 
 let load w s file =
     let ct = Vyos1x.Config_file.load_config file in

--- a/src/session.ml
+++ b/src/session.ml
@@ -107,6 +107,13 @@ let delete w s path =
     let config = apply_cfg_op op s.proposed_config in
     {s with proposed_config=config; changeset=(op :: s.changeset)}
 
+let load w s file =
+    let ct = Vyos1x.Config_file.load_config file in
+    match ct with
+    | Error e -> raise (Session_error (Printf.sprintf "Error loading config: %s" e))
+    | Ok config ->
+        validate_tree w config; {s with proposed_config=config;}
+
 let get_value w s path =
     if not (VT.exists s.proposed_config path) then
         raise (Session_error ("Config path does not exist"))

--- a/src/session.ml
+++ b/src/session.ml
@@ -114,6 +114,13 @@ let load w s file =
     | Ok config ->
         validate_tree w config; {s with proposed_config=config;}
 
+let save w s file =
+    let ct = w.running_config in
+    let res = Vyos1x.Config_file.save_config ct file in
+    match res with
+    | Error e -> raise (Session_error (Printf.sprintf "Error saving config: %s" e))
+    | Ok () -> s
+
 let get_value w s path =
     if not (VT.exists s.proposed_config path) then
         raise (Session_error ("Config path does not exist"))

--- a/src/session.ml
+++ b/src/session.ml
@@ -102,7 +102,6 @@ let set w s path =
     {s with proposed_config=config; changeset=(op :: s.changeset)}
 
 let delete w s path =
-    let _ = validate w s path in
     let path, value = split_path w s path in
     let op = CfgDelete (path, value) in
     let config = apply_cfg_op op s.proposed_config in

--- a/src/session.ml
+++ b/src/session.ml
@@ -69,6 +69,21 @@ let validate w _s path =
         RT.validate_path D.(w.dirs.validators) w.reference_tree path
     with RT.Validation_error x -> raise (Session_error x)
 
+let validate_tree w' t =
+    let validate_path w out path =
+        let res =
+            try
+                RT.validate_path D.(w.dirs.validators) w.reference_tree path;
+                out
+            with RT.Validation_error x -> out ^ x
+        in res
+    in
+    let paths = CT.value_paths_of_tree t in
+    let out = List.fold_left (validate_path w') "" paths in
+    match out with
+    | "" -> ()
+    | _ -> raise (Session_error out)
+
 let split_path w _s path =
     RT.split_path w.reference_tree path
 

--- a/src/session.ml
+++ b/src/session.ml
@@ -107,6 +107,9 @@ let delete w s path =
     let config = apply_cfg_op op s.proposed_config in
     {s with proposed_config=config; changeset=(op :: s.changeset)}
 
+let discard w s =
+    {s with proposed_config=w.running_config}
+
 let load w s file =
     let ct = Vyos1x.Config_file.load_config file in
     match ct with

--- a/src/session.mli
+++ b/src/session.mli
@@ -32,6 +32,8 @@ val set : world -> session_data -> string list -> session_data
 
 val delete : world -> session_data -> string list -> session_data
 
+val discard : world -> session_data -> session_data
+
 val load : world -> session_data -> string -> session_data
 
 val save : world -> session_data -> string -> session_data

--- a/src/session.mli
+++ b/src/session.mli
@@ -32,6 +32,8 @@ val set : world -> session_data -> string list -> session_data
 
 val delete : world -> session_data -> string list -> session_data
 
+val load : world -> session_data -> string -> session_data
+
 val get_value : world -> session_data -> string list -> string
 
 val get_values : world -> session_data -> string list -> string list

--- a/src/session.mli
+++ b/src/session.mli
@@ -34,6 +34,8 @@ val delete : world -> session_data -> string list -> session_data
 
 val load : world -> session_data -> string -> session_data
 
+val save : world -> session_data -> string -> session_data
+
 val get_value : world -> session_data -> string list -> string
 
 val get_values : world -> session_data -> string list -> string list

--- a/src/session.mli
+++ b/src/session.mli
@@ -34,6 +34,8 @@ val delete : world -> session_data -> string list -> session_data
 
 val discard : world -> session_data -> session_data
 
+val session_changed : world -> session_data -> bool
+
 val load : world -> session_data -> string -> session_data
 
 val save : world -> session_data -> string -> session_data

--- a/src/startup.mli
+++ b/src/startup.mli
@@ -14,8 +14,6 @@ val create_server :
     (Lwt_unix.file_descr * Lwt_unix.sockaddr -> unit Lwt.t) ->
     Lwt_unix.file_descr -> unit -> 'a Lwt.t
 
-val load_config : string -> (Vyos1x.Config_tree.t, string) result
-
 val load_config_failsafe : string -> string -> Vyos1x.Config_tree.t
 
 val load_interface_definitions : string -> (Vyos1x.Reference_tree.t, string) result

--- a/src/vycli.ml
+++ b/src/vycli.ml
@@ -2,7 +2,7 @@ open Vyconfd_client.Vyconf_client
 open Vyconf_connect.Vyconf_pbt
 
 type op_t =
-    | OpStatus
+    | OpPrompt
     | OpSetupSession
     | OpTeardownSession
     | OpShowConfig
@@ -35,7 +35,7 @@ let args = [
     ("--exists", Arg.Unit (fun () -> op := Some OpExists), "Check if specified path exists");
     ("--list-children", Arg.Unit (fun () -> op := Some OpListChildren), "List children of the node at the specified path");
     ("--show-config", Arg.Unit (fun () -> op := Some OpShowConfig), "Show the configuration at the specified path");
-    ("--status", Arg.Unit (fun () -> op := Some OpStatus), "Send a status/keepalive message");
+    ("--prompt", Arg.Unit (fun () -> op := Some OpPrompt), "Send a status/keepalive message");
     ("--validate", Arg.Unit (fun () -> op := Some OpValidate), "Validate path");
     ("--reload-reftree", Arg.Unit (fun () -> op := Some OpReloadReftree), "Reload reference tree");
    ]
@@ -59,8 +59,8 @@ let main socket op path out_format config_format =
     | Some o ->
         begin
             match o with
-            | OpStatus ->
-                let%lwt resp = get_status client in
+            | OpPrompt ->
+                let%lwt resp = prompt client in
                 begin
                     match resp.status with
                     | Success -> Ok "" |> Lwt.return

--- a/src/vyconf_client.ml
+++ b/src/vyconf_client.ml
@@ -48,8 +48,8 @@ let do_request client req =
     let%lwt resp = Vyconf_connect.Message.read client.ic in
     decode_pb_response (Pbrt.Decoder.of_bytes resp) |> Lwt.return
 
-let get_status client =
-    let req = Status in
+let prompt client =
+    let req = Prompt in
     let%lwt resp = do_request client req in
     Lwt.return resp
 

--- a/src/vyconf_client.mli
+++ b/src/vyconf_client.mli
@@ -1,31 +1,12 @@
 type t
 
-type status =
-  | Success 
-  | Fail 
-  | Invalid_path 
-  | Invalid_value 
-  | Commit_in_progress 
-  | Configuration_locked 
-  | Internal_error 
-  | Permission_denied 
-  | Path_already_exists 
-
-type response = {
-  status : status;
-  output : string option;
-  error : string option;
-  warning : string option;
-}
-
-
 val create : ?token:(string option) -> string -> Vyconf_connect.Vyconf_pbt.request_output_format -> Vyconf_connect.Vyconf_pbt.request_config_format -> t Lwt.t
 
 val get_token : t -> (string, string) result Lwt.t
 
 val shutdown : t -> t Lwt.t
 
-val get_status : t -> response Lwt.t
+val prompt : t -> Vyconf_connect.Vyconf_pbt.response Lwt.t
 
 val setup_session : ?on_behalf_of:(int option) -> t -> string -> (t, string) result Lwt.t
 

--- a/src/vyconf_pbt.ml
+++ b/src/vyconf_pbt.ml
@@ -141,6 +141,7 @@ type request =
   | Validate of request_validate
   | Teardown of request_teardown
   | Reload_reftree of request_reload_reftree
+  | Load of request_load
 
 type request_envelope = {
   token : string option;
@@ -795,6 +796,7 @@ let rec pp_request fmt (v:request) =
   | Validate x -> Format.fprintf fmt "@[<hv2>Validate(@,%a)@]" pp_request_validate x
   | Teardown x -> Format.fprintf fmt "@[<hv2>Teardown(@,%a)@]" pp_request_teardown x
   | Reload_reftree x -> Format.fprintf fmt "@[<hv2>Reload_reftree(@,%a)@]" pp_request_reload_reftree x
+  | Load x -> Format.fprintf fmt "@[<hv2>Load(@,%a)@]" pp_request_load x
 
 let rec pp_request_envelope fmt (v:request_envelope) = 
   let pp_i fmt () =
@@ -1153,6 +1155,9 @@ let rec encode_pb_request (v:request) encoder =
   | Reload_reftree x ->
     Pbrt.Encoder.nested encode_pb_request_reload_reftree x encoder;
     Pbrt.Encoder.key 23 Pbrt.Bytes encoder; 
+  | Load x ->
+    Pbrt.Encoder.nested encode_pb_request_load x encoder;
+    Pbrt.Encoder.key 24 Pbrt.Bytes encoder; 
   end
 
 let rec encode_pb_request_envelope (v:request_envelope) encoder = 
@@ -1797,6 +1802,7 @@ let rec decode_pb_request d =
       | Some (21, _) -> (Validate (decode_pb_request_validate (Pbrt.Decoder.nested d)) : request) 
       | Some (22, _) -> (Teardown (decode_pb_request_teardown (Pbrt.Decoder.nested d)) : request) 
       | Some (23, _) -> (Reload_reftree (decode_pb_request_reload_reftree (Pbrt.Decoder.nested d)) : request) 
+      | Some (24, _) -> (Load (decode_pb_request_load (Pbrt.Decoder.nested d)) : request) 
       | Some (n, payload_kind) -> (
         Pbrt.Decoder.skip d payload_kind; 
         loop () 

--- a/src/vyconf_pbt.mli
+++ b/src/vyconf_pbt.mli
@@ -43,6 +43,10 @@ type request_discard = {
   dummy : int32 option;
 }
 
+type request_session_changed = {
+  dummy : int32 option;
+}
+
 type request_rename = {
   edit_level : string list;
   from : string;
@@ -154,6 +158,7 @@ type request =
   | Reload_reftree of request_reload_reftree
   | Load of request_load
   | Discard of request_discard
+  | Session_changed of request_session_changed
 
 type request_envelope = {
   token : string option;
@@ -227,6 +232,12 @@ val default_request_discard :
   unit ->
   request_discard
 (** [default_request_discard ()] is the default value for type [request_discard] *)
+
+val default_request_session_changed : 
+  ?dummy:int32 option ->
+  unit ->
+  request_session_changed
+(** [default_request_session_changed ()] is the default value for type [request_session_changed] *)
 
 val default_request_rename : 
   ?edit_level:string list ->
@@ -399,6 +410,9 @@ val pp_request_delete : Format.formatter -> request_delete -> unit
 val pp_request_discard : Format.formatter -> request_discard -> unit 
 (** [pp_request_discard v] formats v *)
 
+val pp_request_session_changed : Format.formatter -> request_session_changed -> unit 
+(** [pp_request_session_changed v] formats v *)
+
 val pp_request_rename : Format.formatter -> request_rename -> unit 
 (** [pp_request_rename v] formats v *)
 
@@ -495,6 +509,9 @@ val encode_pb_request_delete : request_delete -> Pbrt.Encoder.t -> unit
 val encode_pb_request_discard : request_discard -> Pbrt.Encoder.t -> unit
 (** [encode_pb_request_discard v encoder] encodes [v] with the given [encoder] *)
 
+val encode_pb_request_session_changed : request_session_changed -> Pbrt.Encoder.t -> unit
+(** [encode_pb_request_session_changed v encoder] encodes [v] with the given [encoder] *)
+
 val encode_pb_request_rename : request_rename -> Pbrt.Encoder.t -> unit
 (** [encode_pb_request_rename v encoder] encodes [v] with the given [encoder] *)
 
@@ -590,6 +607,9 @@ val decode_pb_request_delete : Pbrt.Decoder.t -> request_delete
 
 val decode_pb_request_discard : Pbrt.Decoder.t -> request_discard
 (** [decode_pb_request_discard decoder] decodes a [request_discard] binary value from [decoder] *)
+
+val decode_pb_request_session_changed : Pbrt.Decoder.t -> request_session_changed
+(** [decode_pb_request_session_changed decoder] decodes a [request_session_changed] binary value from [decoder] *)
 
 val decode_pb_request_rename : Pbrt.Decoder.t -> request_rename
 (** [decode_pb_request_rename decoder] decodes a [request_rename] binary value from [decoder] *)

--- a/src/vyconf_pbt.mli
+++ b/src/vyconf_pbt.mli
@@ -148,6 +148,7 @@ type request =
   | Validate of request_validate
   | Teardown of request_teardown
   | Reload_reftree of request_reload_reftree
+  | Load of request_load
 
 type request_envelope = {
   token : string option;

--- a/src/vyconf_pbt.mli
+++ b/src/vyconf_pbt.mli
@@ -15,7 +15,7 @@ type request_output_format =
   | Out_plain 
   | Out_json 
 
-type request_status = unit
+type request_prompt = unit
 
 type request_setup_session = {
   client_application : string option;
@@ -125,7 +125,7 @@ type request_reload_reftree = {
 }
 
 type request =
-  | Status
+  | Prompt
   | Setup_session of request_setup_session
   | Set of request_set
   | Delete of request_delete
@@ -154,7 +154,7 @@ type request_envelope = {
   request : request;
 }
 
-type status =
+type errnum =
   | Success 
   | Fail 
   | Invalid_path 
@@ -166,7 +166,7 @@ type status =
   | Path_already_exists 
 
 type response = {
-  status : status;
+  status : errnum;
   output : string option;
   error : string option;
   warning : string option;
@@ -181,8 +181,8 @@ val default_request_config_format : unit -> request_config_format
 val default_request_output_format : unit -> request_output_format
 (** [default_request_output_format ()] is the default value for type [request_output_format] *)
 
-val default_request_status : unit
-(** [default_request_status ()] is the default value for type [request_status] *)
+val default_request_prompt : unit
+(** [default_request_prompt ()] is the default value for type [request_prompt] *)
 
 val default_request_setup_session : 
   ?client_application:string option ->
@@ -345,11 +345,11 @@ val default_request_envelope :
   request_envelope
 (** [default_request_envelope ()] is the default value for type [request_envelope] *)
 
-val default_status : unit -> status
-(** [default_status ()] is the default value for type [status] *)
+val default_errnum : unit -> errnum
+(** [default_errnum ()] is the default value for type [errnum] *)
 
 val default_response : 
-  ?status:status ->
+  ?status:errnum ->
   ?output:string option ->
   ?error:string option ->
   ?warning:string option ->
@@ -366,8 +366,8 @@ val pp_request_config_format : Format.formatter -> request_config_format -> unit
 val pp_request_output_format : Format.formatter -> request_output_format -> unit 
 (** [pp_request_output_format v] formats v *)
 
-val pp_request_status : Format.formatter -> request_status -> unit 
-(** [pp_request_status v] formats v *)
+val pp_request_prompt : Format.formatter -> request_prompt -> unit 
+(** [pp_request_prompt v] formats v *)
 
 val pp_request_setup_session : Format.formatter -> request_setup_session -> unit 
 (** [pp_request_setup_session v] formats v *)
@@ -444,8 +444,8 @@ val pp_request : Format.formatter -> request -> unit
 val pp_request_envelope : Format.formatter -> request_envelope -> unit 
 (** [pp_request_envelope v] formats v *)
 
-val pp_status : Format.formatter -> status -> unit 
-(** [pp_status v] formats v *)
+val pp_errnum : Format.formatter -> errnum -> unit 
+(** [pp_errnum v] formats v *)
 
 val pp_response : Format.formatter -> response -> unit 
 (** [pp_response v] formats v *)
@@ -459,8 +459,8 @@ val encode_pb_request_config_format : request_config_format -> Pbrt.Encoder.t ->
 val encode_pb_request_output_format : request_output_format -> Pbrt.Encoder.t -> unit
 (** [encode_pb_request_output_format v encoder] encodes [v] with the given [encoder] *)
 
-val encode_pb_request_status : request_status -> Pbrt.Encoder.t -> unit
-(** [encode_pb_request_status v encoder] encodes [v] with the given [encoder] *)
+val encode_pb_request_prompt : request_prompt -> Pbrt.Encoder.t -> unit
+(** [encode_pb_request_prompt v encoder] encodes [v] with the given [encoder] *)
 
 val encode_pb_request_setup_session : request_setup_session -> Pbrt.Encoder.t -> unit
 (** [encode_pb_request_setup_session v encoder] encodes [v] with the given [encoder] *)
@@ -537,8 +537,8 @@ val encode_pb_request : request -> Pbrt.Encoder.t -> unit
 val encode_pb_request_envelope : request_envelope -> Pbrt.Encoder.t -> unit
 (** [encode_pb_request_envelope v encoder] encodes [v] with the given [encoder] *)
 
-val encode_pb_status : status -> Pbrt.Encoder.t -> unit
-(** [encode_pb_status v encoder] encodes [v] with the given [encoder] *)
+val encode_pb_errnum : errnum -> Pbrt.Encoder.t -> unit
+(** [encode_pb_errnum v encoder] encodes [v] with the given [encoder] *)
 
 val encode_pb_response : response -> Pbrt.Encoder.t -> unit
 (** [encode_pb_response v encoder] encodes [v] with the given [encoder] *)
@@ -552,8 +552,8 @@ val decode_pb_request_config_format : Pbrt.Decoder.t -> request_config_format
 val decode_pb_request_output_format : Pbrt.Decoder.t -> request_output_format
 (** [decode_pb_request_output_format decoder] decodes a [request_output_format] binary value from [decoder] *)
 
-val decode_pb_request_status : Pbrt.Decoder.t -> request_status
-(** [decode_pb_request_status decoder] decodes a [request_status] binary value from [decoder] *)
+val decode_pb_request_prompt : Pbrt.Decoder.t -> request_prompt
+(** [decode_pb_request_prompt decoder] decodes a [request_prompt] binary value from [decoder] *)
 
 val decode_pb_request_setup_session : Pbrt.Decoder.t -> request_setup_session
 (** [decode_pb_request_setup_session decoder] decodes a [request_setup_session] binary value from [decoder] *)
@@ -630,8 +630,8 @@ val decode_pb_request : Pbrt.Decoder.t -> request
 val decode_pb_request_envelope : Pbrt.Decoder.t -> request_envelope
 (** [decode_pb_request_envelope decoder] decodes a [request_envelope] binary value from [decoder] *)
 
-val decode_pb_status : Pbrt.Decoder.t -> status
-(** [decode_pb_status decoder] decodes a [status] binary value from [decoder] *)
+val decode_pb_errnum : Pbrt.Decoder.t -> errnum
+(** [decode_pb_errnum decoder] decodes a [errnum] binary value from [decoder] *)
 
 val decode_pb_response : Pbrt.Decoder.t -> response
 (** [decode_pb_response decoder] decodes a [response] binary value from [decoder] *)

--- a/src/vyconf_pbt.mli
+++ b/src/vyconf_pbt.mli
@@ -39,6 +39,10 @@ type request_delete = {
   path : string list;
 }
 
+type request_discard = {
+  dummy : int32 option;
+}
+
 type request_rename = {
   edit_level : string list;
   from : string;
@@ -149,6 +153,7 @@ type request =
   | Teardown of request_teardown
   | Reload_reftree of request_reload_reftree
   | Load of request_load
+  | Discard of request_discard
 
 type request_envelope = {
   token : string option;
@@ -216,6 +221,12 @@ val default_request_delete :
   unit ->
   request_delete
 (** [default_request_delete ()] is the default value for type [request_delete] *)
+
+val default_request_discard : 
+  ?dummy:int32 option ->
+  unit ->
+  request_discard
+(** [default_request_discard ()] is the default value for type [request_discard] *)
 
 val default_request_rename : 
   ?edit_level:string list ->
@@ -385,6 +396,9 @@ val pp_request_set : Format.formatter -> request_set -> unit
 val pp_request_delete : Format.formatter -> request_delete -> unit 
 (** [pp_request_delete v] formats v *)
 
+val pp_request_discard : Format.formatter -> request_discard -> unit 
+(** [pp_request_discard v] formats v *)
+
 val pp_request_rename : Format.formatter -> request_rename -> unit 
 (** [pp_request_rename v] formats v *)
 
@@ -478,6 +492,9 @@ val encode_pb_request_set : request_set -> Pbrt.Encoder.t -> unit
 val encode_pb_request_delete : request_delete -> Pbrt.Encoder.t -> unit
 (** [encode_pb_request_delete v encoder] encodes [v] with the given [encoder] *)
 
+val encode_pb_request_discard : request_discard -> Pbrt.Encoder.t -> unit
+(** [encode_pb_request_discard v encoder] encodes [v] with the given [encoder] *)
+
 val encode_pb_request_rename : request_rename -> Pbrt.Encoder.t -> unit
 (** [encode_pb_request_rename v encoder] encodes [v] with the given [encoder] *)
 
@@ -570,6 +587,9 @@ val decode_pb_request_set : Pbrt.Decoder.t -> request_set
 
 val decode_pb_request_delete : Pbrt.Decoder.t -> request_delete
 (** [decode_pb_request_delete decoder] decodes a [request_delete] binary value from [decoder] *)
+
+val decode_pb_request_discard : Pbrt.Decoder.t -> request_discard
+(** [decode_pb_request_discard decoder] decodes a [request_discard] binary value from [decoder] *)
 
 val decode_pb_request_rename : Pbrt.Decoder.t -> request_rename
 (** [decode_pb_request_rename decoder] decodes a [request_rename] binary value from [decoder] *)

--- a/src/vyconfd.ml
+++ b/src/vyconfd.ml
@@ -163,6 +163,14 @@ let delete world token (req: request_delete) =
         response_tmpl
     with Session.Session_error msg -> {response_tmpl with status=Fail; error=(Some msg)}
 
+let discard world token (_req: request_discard) =
+    try
+        let session = Session.discard world (find_session token)
+        in
+        Hashtbl.replace sessions token session;
+        response_tmpl
+    with Session.Session_error msg -> {response_tmpl with status=Fail; error=(Some msg)}
+
 let load world token (req: request_load) =
     try
         let session = Session.load world (find_session token) req.location
@@ -266,6 +274,7 @@ let rec handle_connection world ic oc () =
                     | Some t, Validate r -> validate world t r
                     | Some t, Set r -> set world t r
                     | Some t, Delete r -> delete world t r
+                    | Some t, Discard r -> discard world t r
                     | Some t, Load r -> load world t r
                     | Some t, Save r -> save world t r
                     | _ -> failwith "Unimplemented"

--- a/src/vyconfd.ml
+++ b/src/vyconfd.ml
@@ -236,7 +236,7 @@ let rec handle_connection world ic oc () =
                | _ as req ->
                begin
                     (match req with
-                    | _, Status -> response_tmpl
+                    | _, Prompt -> response_tmpl
                     | _, Setup_session r -> setup_session world r
                     | _, Reload_reftree r -> reload_reftree world r
                     | None, _ -> {response_tmpl with status=Fail; output=(Some "Operation requires session token")}

--- a/src/vyconfd.ml
+++ b/src/vyconfd.ml
@@ -171,6 +171,13 @@ let load world token (req: request_load) =
         response_tmpl
     with Session.Session_error msg -> {response_tmpl with status=Fail; error=(Some msg)}
 
+let save world token (req: request_save) =
+    try
+        let _ = Session.save world (find_session token) req.location
+        in
+        response_tmpl
+    with Session.Session_error msg -> {response_tmpl with status=Fail; error=(Some msg)}
+
 let commit world token (req: request_commit) =
     let s = find_session token in
     let at = world.Session.running_config in
@@ -260,6 +267,7 @@ let rec handle_connection world ic oc () =
                     | Some t, Set r -> set world t r
                     | Some t, Delete r -> delete world t r
                     | Some t, Load r -> load world t r
+                    | Some t, Save r -> save world t r
                     | _ -> failwith "Unimplemented"
                     ) |> Lwt.return
                end

--- a/src/vyconfd.ml
+++ b/src/vyconfd.ml
@@ -95,6 +95,10 @@ let teardown token =
     with Not_found ->
         {response_tmpl with status=Fail; error=(Some "Session not found")}
 
+let session_changed world token (_req: request_session_changed) =
+    if Session.session_changed world (find_session token) then response_tmpl
+    else {response_tmpl with status=Fail}
+
 let exists world token (req: request_exists) =
     if Session.exists world (find_session token) req.path then response_tmpl
     else {response_tmpl with status=Fail}
@@ -275,6 +279,7 @@ let rec handle_connection world ic oc () =
                     | Some t, Set r -> set world t r
                     | Some t, Delete r -> delete world t r
                     | Some t, Discard r -> discard world t r
+                    | Some t, Session_changed r -> session_changed world t r
                     | Some t, Load r -> load world t r
                     | Some t, Save r -> save world t r
                     | _ -> failwith "Unimplemented"

--- a/src/vyconfd.ml
+++ b/src/vyconfd.ml
@@ -163,6 +163,14 @@ let delete world token (req: request_delete) =
         response_tmpl
     with Session.Session_error msg -> {response_tmpl with status=Fail; error=(Some msg)}
 
+let load world token (req: request_load) =
+    try
+        let session = Session.load world (find_session token) req.location
+        in
+        Hashtbl.replace sessions token session;
+        response_tmpl
+    with Session.Session_error msg -> {response_tmpl with status=Fail; error=(Some msg)}
+
 let commit world token (req: request_commit) =
     let s = find_session token in
     let at = world.Session.running_config in
@@ -251,6 +259,7 @@ let rec handle_connection world ic oc () =
                     | Some t, Validate r -> validate world t r
                     | Some t, Set r -> set world t r
                     | Some t, Delete r -> delete world t r
+                    | Some t, Load r -> load world t r
                     | _ -> failwith "Unimplemented"
                     ) |> Lwt.return
                end


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Requires companion PR:
https://github.com/vyos/vyos1x-config/pull/41

Add operations sufficient to replace those in configsession that are currently handled by legacy binary my_*.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

https://github.com/vyos/vyos1x-config/pull/41

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
